### PR TITLE
Don't touch /www permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,10 @@ FROM        progrium/busybox
 MAINTAINER  Fletcher Nichol <fnichol@nichol.ca>
 
 RUN opkg-install uhttpd
-RUN printf '#!/bin/sh\nset -e\n\nchmod 755 /www\nexec /usr/sbin/uhttpd $*\n' > /usr/sbin/run_uhttpd && chmod 755 /usr/sbin/run_uhttpd
 
 VOLUME ["/www"]
 
 EXPOSE 80
 
-ENTRYPOINT ["/usr/sbin/run_uhttpd", "-f", "-p", "80", "-h", "/www"]
+ENTRYPOINT ["/usr/sbin/uhttpd", "-f", "-p", "80", "-h", "/www"]
 CMD [""]


### PR DESCRIPTION
Hi,

I'm not sure about the reason you create shell wrapper around the daemon and this is fine but in my case it is problematic to change /www permissions because it is a volume from another container and is owned by root and all permissions are already fine.

So' I removed this and also the shell wrapper entirely. For me it still works as intended. Feel free to accept this pull request if it works for you or just drop it ;-)

Cheers,